### PR TITLE
Remove caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-            - /root/cache
+            - /root/.cache
             - ./node_modules
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-            - ~/.cache
+            - /root/cache
             - ./node_modules
 
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,17 +6,8 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-
       - run:
           command: npm install
-
-      - save_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-          paths:
-            - /root/.cache
-            - ./node_modules
 
       - run:
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
-            - ./.cache
+            - ~/.cache
             - ./node_modules
 
       - run:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ qawolf:
 
   cache:
     paths:
-      - .cache/
+      - ~/.cache/
       - node_modules/
 
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ qawolf:
 
   cache:
     paths:
-      - ~/.cache/
+      - /root/.cache/
       - node_modules/
 
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,6 @@
 qawolf:
   image: qawolf/playwright-ci:v0.10.0
 
-  cache:
-    paths:
-      - /root/.cache/
-      - node_modules/
-
   script:
     - npm install
     # # Start local server

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,8 +4,8 @@ pipelines:
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - ~/.cache
-          - node_modules
+          - node
+          - playwright
         script:
           - npm install
         
@@ -14,3 +14,7 @@ pipelines:
           # replace below with command you want to run, example for running a script below
           # - node myScript.js
           - npm test
+
+definitions:
+  caches:
+    playwright: ~/.cache

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -3,9 +3,6 @@ pipelines:
     - step:
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
-        caches:
-          - node
-          - playwright
         script:
           - npm install
         
@@ -14,7 +11,3 @@ pipelines:
           # replace below with command you want to run, example for running a script below
           # - node myScript.js
           - npm test
-
-definitions:
-  caches:
-    playwright: ~/.cache

--- a/bitbucket-pipelines.yml
+++ b/bitbucket-pipelines.yml
@@ -4,7 +4,8 @@ pipelines:
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - node
+          - ~/.cache
+          - node_modules
         script:
           - npm install
         

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-ci",
-  "version": "0.10.0",
+  "version": "0.10.0-invalidate-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-ci",
-  "version": "0.10.0-invalidate-0",
+  "version": "0.10.0-invalidate-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-ci",
-  "version": "0.10.0-invalidate-1",
+  "version": "0.10.0-invalidate-2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "playwright-ci",
-  "version": "0.10.0-invalidate-2",
+  "version": "0.10.0-invalidate-3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "QA Wolf",
   "name": "playwright-ci",
   "license": "BSD-3.0",
-  "version": "0.10.0-invalidate-3",
+  "version": "0.10.0",
   "description": "☁️ Set up Playwright in CI with one command",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "QA Wolf",
   "name": "playwright-ci",
   "license": "BSD-3.0",
-  "version": "0.10.0-invalidate-1",
+  "version": "0.10.0-invalidate-2",
   "description": "☁️ Set up Playwright in CI with one command",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "QA Wolf",
   "name": "playwright-ci",
   "license": "BSD-3.0",
-  "version": "0.10.0",
+  "version": "0.10.0-invalidate-0",
   "description": "☁️ Set up Playwright in CI with one command",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "QA Wolf",
   "name": "playwright-ci",
   "license": "BSD-3.0",
-  "version": "0.10.0-invalidate-0",
+  "version": "0.10.0-invalidate-1",
   "description": "☁️ Set up Playwright in CI with one command",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "QA Wolf",
   "name": "playwright-ci",
   "license": "BSD-3.0",
-  "version": "0.10.0-invalidate-2",
+  "version": "0.10.0-invalidate-3",
   "description": "☁️ Set up Playwright in CI with one command",
   "main": "./build/index.js",
   "types": "./build/index.d.ts",

--- a/static/bitbucket.hbs
+++ b/static/bitbucket.hbs
@@ -8,7 +8,8 @@ pipelines:
         {{/if}}
         image: qawolf/playwright-ci:v{{{version}}}
         caches:
-          - node
+          - ~/.cache
+          - node_modules
         script:
           - npm install
         

--- a/static/bitbucket.hbs
+++ b/static/bitbucket.hbs
@@ -7,9 +7,6 @@ pipelines:
         name: Playwright Tests
         {{/if}}
         image: qawolf/playwright-ci:v{{{version}}}
-        caches:
-          - node
-          - playwright
         script:
           - npm install
         
@@ -26,7 +23,3 @@ pipelines:
         artifacts:
           - artifacts/**
         {{/if}}
-
-definitions:
-  caches:
-    playwright: ~/.cache

--- a/static/bitbucket.hbs
+++ b/static/bitbucket.hbs
@@ -8,8 +8,8 @@ pipelines:
         {{/if}}
         image: qawolf/playwright-ci:v{{{version}}}
         caches:
-          - ~/.cache
-          - node_modules
+          - node
+          - playwright
         script:
           - npm install
         
@@ -26,3 +26,7 @@ pipelines:
         artifacts:
           - artifacts/**
         {{/if}}
+
+definitions:
+  caches:
+    playwright: ~/.cache

--- a/static/circleci.hbs
+++ b/static/circleci.hbs
@@ -6,17 +6,8 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: dependency-cache-\{{ checksum "package-lock.json" }}
-
       - run:
           command: npm install
-
-      - save_cache:
-          key: dependency-cache-\{{ checksum "package-lock.json" }}
-          paths:
-            - /root/.cache
-            - ./node_modules
 
       - run:
           command: |

--- a/static/circleci.hbs
+++ b/static/circleci.hbs
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-\{{ checksum "package-lock.json" }}
           paths:
-            - /root/cache
+            - /root/.cache
             - ./node_modules
 
       - run:

--- a/static/circleci.hbs
+++ b/static/circleci.hbs
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-\{{ checksum "package-lock.json" }}
           paths:
-            - ./.cache
+            - ~/.cache
             - ./node_modules
 
       - run:

--- a/static/circleci.hbs
+++ b/static/circleci.hbs
@@ -15,7 +15,7 @@ jobs:
       - save_cache:
           key: dependency-cache-\{{ checksum "package-lock.json" }}
           paths:
-            - ~/.cache
+            - /root/cache
             - ./node_modules
 
       - run:

--- a/static/gitlab.hbs
+++ b/static/gitlab.hbs
@@ -3,7 +3,7 @@ qawolf:
 
   cache:
     paths:
-      - ~/.cache/
+      - /root/cache/
       - node_modules/
 
   script:

--- a/static/gitlab.hbs
+++ b/static/gitlab.hbs
@@ -1,11 +1,6 @@
 qawolf:
   image: qawolf/playwright-ci:v{{{version}}}
 
-  cache:
-    paths:
-      - /root/.cache/
-      - node_modules/
-
   script:
     - npm install
     # # Start local server

--- a/static/gitlab.hbs
+++ b/static/gitlab.hbs
@@ -3,7 +3,7 @@ qawolf:
 
   cache:
     paths:
-      - .cache/
+      - ~/.cache/
       - node_modules/
 
   script:

--- a/static/gitlab.hbs
+++ b/static/gitlab.hbs
@@ -3,7 +3,7 @@ qawolf:
 
   cache:
     paths:
-      - /root/cache/
+      - /root/.cache/
       - node_modules/
 
   script:

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -143,11 +143,6 @@ exports[`buildCiTemplate builds playwright templates: gitlab 1`] = `
 "qawolf:
   image: qawolf/playwright-ci:v0.10.0
 
-  cache:
-    paths:
-      - /root/.cache/
-      - node_modules/
-
   script:
     - npm install
     # # Start local server
@@ -349,11 +344,6 @@ jobs:
 exports[`buildCiTemplate builds qawolf templates: gitlab_qawolf 1`] = `
 "qawolf:
   image: qawolf/playwright-ci:v0.10.0
-
-  cache:
-    paths:
-      - /root/.cache/
-      - node_modules/
 
   script:
     - npm install

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -67,7 +67,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - ~/.cache
+            - /root/cache
             - ./node_modules
 
       - run:
@@ -141,7 +141,7 @@ exports[`buildCiTemplate builds playwright templates: gitlab 1`] = `
 
   cache:
     paths:
-      - ~/.cache/
+      - /root/cache/
       - node_modules/
 
   script:
@@ -255,7 +255,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - ~/.cache
+            - /root/cache
             - ./node_modules
 
       - run:
@@ -344,7 +344,7 @@ exports[`buildCiTemplate builds qawolf templates: gitlab_qawolf 1`] = `
 
   cache:
     paths:
-      - ~/.cache/
+      - /root/cache/
       - node_modules/
 
   script:

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -37,8 +37,8 @@ exports[`buildCiTemplate builds playwright templates: bitbucket 1`] = `
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - ~/.cache
-          - node_modules
+          - node
+          - playwright
         script:
           - npm install
         
@@ -47,7 +47,10 @@ exports[`buildCiTemplate builds playwright templates: bitbucket 1`] = `
           # replace below with command you want to run, example for running a script below
           # - node myScript.js
           - npm test
-"
+
+definitions:
+  caches:
+    playwright: ~/.cache"
 `;
 
 exports[`buildCiTemplate builds playwright templates: circleci 1`] = `
@@ -68,7 +71,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - /root/cache
+            - /root/.cache
             - ./node_modules
 
       - run:
@@ -142,7 +145,7 @@ exports[`buildCiTemplate builds playwright templates: gitlab 1`] = `
 
   cache:
     paths:
-      - /root/cache/
+      - /root/.cache/
       - node_modules/
 
   script:
@@ -226,8 +229,8 @@ exports[`buildCiTemplate builds qawolf templates: bitbucket_qawolf 1`] = `
         name: QA Wolf Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - ~/.cache
-          - node_modules
+          - node
+          - playwright
         script:
           - npm install
         
@@ -236,7 +239,10 @@ exports[`buildCiTemplate builds qawolf templates: bitbucket_qawolf 1`] = `
           - QAW_ARTIFACT_PATH=artifacts npx qawolf test --headless
         artifacts:
           - artifacts/**
-"
+
+definitions:
+  caches:
+    playwright: ~/.cache"
 `;
 
 exports[`buildCiTemplate builds qawolf templates: circleci_qawolf 1`] = `
@@ -257,7 +263,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - /root/cache
+            - /root/.cache
             - ./node_modules
 
       - run:
@@ -346,7 +352,7 @@ exports[`buildCiTemplate builds qawolf templates: gitlab_qawolf 1`] = `
 
   cache:
     paths:
-      - /root/cache/
+      - /root/.cache/
       - node_modules/
 
   script:

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -36,9 +36,6 @@ exports[`buildCiTemplate builds playwright templates: bitbucket 1`] = `
     - step:
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
-        caches:
-          - node
-          - playwright
         script:
           - npm install
         
@@ -47,10 +44,7 @@ exports[`buildCiTemplate builds playwright templates: bitbucket 1`] = `
           # replace below with command you want to run, example for running a script below
           # - node myScript.js
           - npm test
-
-definitions:
-  caches:
-    playwright: ~/.cache"
+"
 `;
 
 exports[`buildCiTemplate builds playwright templates: circleci 1`] = `
@@ -62,17 +56,8 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
-
       - run:
           command: npm install
-
-      - save_cache:
-          key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
-          paths:
-            - /root/.cache
-            - ./node_modules
 
       - run:
           command: |
@@ -223,9 +208,6 @@ exports[`buildCiTemplate builds qawolf templates: bitbucket_qawolf 1`] = `
     - step:
         name: QA Wolf Tests
         image: qawolf/playwright-ci:v0.10.0
-        caches:
-          - node
-          - playwright
         script:
           - npm install
         
@@ -234,10 +216,7 @@ exports[`buildCiTemplate builds qawolf templates: bitbucket_qawolf 1`] = `
           - QAW_ARTIFACT_PATH=artifacts npx qawolf test --headless
         artifacts:
           - artifacts/**
-
-definitions:
-  caches:
-    playwright: ~/.cache"
+"
 `;
 
 exports[`buildCiTemplate builds qawolf templates: circleci_qawolf 1`] = `
@@ -249,17 +228,8 @@ jobs:
     steps:
       - checkout
 
-      - restore_cache:
-          key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
-
       - run:
           command: npm install
-
-      - save_cache:
-          key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
-          paths:
-            - /root/.cache
-            - ./node_modules
 
       - run:
           command: |

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -37,7 +37,8 @@ exports[`buildCiTemplate builds playwright templates: bitbucket 1`] = `
         name: Playwright Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - node
+          - ~/.cache
+          - node_modules
         script:
           - npm install
         
@@ -225,7 +226,8 @@ exports[`buildCiTemplate builds qawolf templates: bitbucket_qawolf 1`] = `
         name: QA Wolf Tests
         image: qawolf/playwright-ci:v0.10.0
         caches:
-          - node
+          - ~/.cache
+          - node_modules
         script:
           - npm install
         

--- a/test/__snapshots__/ci.test.ts.snap
+++ b/test/__snapshots__/ci.test.ts.snap
@@ -67,7 +67,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - ./.cache
+            - ~/.cache
             - ./node_modules
 
       - run:
@@ -141,7 +141,7 @@ exports[`buildCiTemplate builds playwright templates: gitlab 1`] = `
 
   cache:
     paths:
-      - .cache/
+      - ~/.cache/
       - node_modules/
 
   script:
@@ -255,7 +255,7 @@ jobs:
       - save_cache:
           key: dependency-cache-{{ checksum \\"package-lock.json\\" }}
           paths:
-            - ./.cache
+            - ~/.cache
             - ./node_modules
 
       - run:
@@ -344,7 +344,7 @@ exports[`buildCiTemplate builds qawolf templates: gitlab_qawolf 1`] = `
 
   cache:
     paths:
-      - .cache/
+      - ~/.cache/
       - node_modules/
 
   script:


### PR DESCRIPTION
For gitlab we cannot cache the browsers in `~/.cache` since those are outside of the project directory.

For [bitbucket](https://bitbucket.org/qawolf/playwright-ci/addon/pipelines/home#!/results/10) and [circleci](https://app.circleci.com/pipelines/github/qawolf/playwright-ci/30/workflows/aa8f6dac-f3e1-4191-a012-075c0c732524/jobs/34) we cannot cache `~/.cache` because firefox has issues when it is restored:

```
error launching browsers TimeoutError: Timed out after 30000 ms while trying to connect to Firefox!
    at Firefox._launchServer (/opt/atlassian/pipelines/agent/build/node_modules/playwright-core/lib/server/firefox.js:109:30)
    at async Firefox.launch (/opt/atlassian/pipelines/agent/build/node_modules/playwright-core/lib/server/firefox.js:41:58)
    at async /opt/atlassian/pipelines/agent/build/test/launch.js:13:15
```

Since we cannot cache the browsers in `~/.cache`, we should not cache `node_modules` because then playwright browsers would not be downloaded.